### PR TITLE
feat(frontend) : set up frontend routes for course details and courselist page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,9 @@ import LoginPage from "./pages/login";
 import ForgotPassword from "./pages/forgotPassword";
 import AcademicPage from "./Modules/Academic/index";
 import ValidateAuth from "./helper/validateauth";
+import CourseManagementPage from "./Modules/Academic/CourseManagement";
+import CourseList from "./Modules/Academic/CourseManagement/CourseList";
+import CourseDetails from "./Modules/Academic/CourseManagement/CourseDetails";
 
 export default function App() {
   const location = useLocation();
@@ -40,6 +43,11 @@ export default function App() {
             </Layout>
           }
         />
+        <Route path="/course-management" element={<Layout />}>
+          <Route index element={<CourseManagementPage />} />
+          <Route path="courses" element={<CourseList />} />
+          <Route path=":courseId" element={<CourseDetails />} />
+        </Route>
         <Route
           path="/profile"
           element={

--- a/src/Modules/Academic/CourseManagement/CourseDetails.jsx
+++ b/src/Modules/Academic/CourseManagement/CourseDetails.jsx
@@ -1,0 +1,9 @@
+function CourseDetails() {
+  return (
+    <div>
+      <h1>Course Details</h1>
+    </div>
+  );
+}
+
+export default CourseDetails;

--- a/src/Modules/Academic/CourseManagement/CourseList.jsx
+++ b/src/Modules/Academic/CourseManagement/CourseList.jsx
@@ -1,0 +1,9 @@
+function CourseList() {
+  return (
+    <div>
+      <h1>Course List</h1>
+    </div>
+  );
+}
+
+export default CourseList;

--- a/src/Modules/Academic/CourseManagement/index.jsx
+++ b/src/Modules/Academic/CourseManagement/index.jsx
@@ -1,0 +1,13 @@
+import { Text } from "@mantine/core";
+import CustomBreadcrumbs from "../../../components/Breadcrumbs";
+
+function CourseManagementPage() {
+  return (
+    <>
+      <CustomBreadcrumbs />
+      <Text>Course management Page</Text>
+    </>
+  );
+}
+
+export default CourseManagementPage;


### PR DESCRIPTION
This PR does the following : 

- Creates the parent route for the course management module
- Creates 2 children routes, `CourseList` and `CourseDetails` children routes
- Initializes the component directory for the module course management 